### PR TITLE
add .dockerignore file to reduce build context size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+venv/*
+.git/*
+.idea/
+.gitignore


### PR DESCRIPTION
I've noticed that `docker-compose up --build` command and other similar actions was taking too much time before even steps in Dockerfile was started. Apparently this was cause of the to heavy build context that was taking `venv` and other stuff inside for each container.
Adding `.dockerignore` file should help.