### PR TITLE
US-14 fix predictions "InsufficientDataAfterRowFilteringError"

### DIFF
--- a/app/latigo/executor/__init__.py
+++ b/app/latigo/executor/__init__.py
@@ -366,7 +366,7 @@ class PredictionExecutor:
                                     datetime.datetime.now() - task_fetch_start
                                 )
                                 logger.info(
-                                    f"Prediction stored after {human_delta(prediction_storage_interval)}\n"
+                                    f"Prediction stored after {human_delta(prediction_storage_interval)}\n\n"
                                 )
                                 self.idle_count(True)
                             else:

--- a/app/latigo/gordo/data_provider.py
+++ b/app/latigo/gordo/data_provider.py
@@ -1,9 +1,10 @@
+import time
 import typing
 import logging
 import pandas as pd
 from datetime import datetime
 
-from latigo.types import TimeRange, LatigoSensorTag
+from latigo.types import TimeRange, LatigoSensorTag, SensorDataSet
 from latigo.sensor_data import SensorDataProviderInterface
 from latigo.types import SensorDataSpec
 
@@ -94,13 +95,12 @@ class LatigoDataProvider(GordoBaseDataProvider):
         if not sensor_data.data:
             logger.error(f"No data.data")
             return
-        data = sensor_data.data.to_gordo_dataframe(tags=tag_list, target_tags=[])
-        if not data:
+
+        if not sensor_data.data:
             logger.error(f"No gordo data")
             return
-        # logger.info(data)
-        for d in data:
-            d = d[((d.index >= train_start_date) & (d.index <= train_end_date))]
+
+        for d in sensor_data.data:
             yield d
         return
 

--- a/app/latigo/gordo/prediction_execution_provider.py
+++ b/app/latigo/gordo/prediction_execution_provider.py
@@ -57,7 +57,7 @@ class GordoPredictionExecutionProvider(PredictionExecutionProviderInterface):
         client = self.gordo_pool.allocate_instance(project_name)
         if not client:
             raise Exception(f"No gordo client found for project '{project_name}' in gordo.execute_prediction()")
-        print_client_debug(client)
+        # print_client_debug(client)
         try:
             result = client.predict(
                 start=sensor_data.time_range.from_time,

--- a/app/latigo/intermediate.py
+++ b/app/latigo/intermediate.py
@@ -1,3 +1,4 @@
+# TODO remove this file. It's probable redundant.
 import logging
 import pprint
 
@@ -129,6 +130,7 @@ class IntermediateFormat:
     def to_gordo_dataframe(
         self, tags: typing.List[SensorTag], target_tags: typing.List[SensorTag]
     ) -> typing.Iterable[pd.Series]:
+        """"NOTE! this method was causing bug. do not use it!"""
         out: typing.List = []
         series_len = len(self.data_frame_data["value"])
         for tag in tags:

--- a/app/latigo/time_series_api/client.py
+++ b/app/latigo/time_series_api/client.py
@@ -112,12 +112,18 @@ class TimeSeriesAPIClient:
     def _fetch_data_for_id(
         self, id: str, time_range: TimeRange
     ) -> typing.Tuple[typing.Optional[typing.Dict], typing.Optional[str]]:
+        """Fetch data points for tag id.
+
+        Note:
+            if "includeOutsidePoints" is True then -> points immediately prior to and following the time window will
+                be included in result and following data filtering before sending for the prediction should be made.
+        """
         url = f"{self.base_url}/{id}/data"
         params = {
             "startTime": time_range.rfc3339_from(),
             "endTime": time_range.rfc3339_to(),
             "limit": 100000,
-            "includeOutsidePoints": True,
+            "includeOutsidePoints": False,
         }
         res = self._get(url=url, params=params)
         return _parse_request_json(res)

--- a/app/latigo/time_series_api/sensor_data_provider.py
+++ b/app/latigo/time_series_api/sensor_data_provider.py
@@ -151,14 +151,10 @@ class TimeSeriesAPISensorDataProvider(TimeSeriesAPIClient, SensorDataProviderInt
                 return None, f"ID missing for {missing_id} tags"
         if not data:
             logger.warning("No gordo data")
-        info = IntermediateFormat()
+
         if completed == len(spec.tag_list):
-            info.from_time_series_api(data)
-            rows = len(info)
-            if rows > 0:
-                logger.info(f"Completed fetching {rows} rows from {completed} tags")
-            else:
-                return None, f"No rows found in {completed} tags"
+            dataframes = SensorDataSet.to_gordo_dataframe(data, time_range.from_time, time_range.to_time)
         else:
             return None, f"Not all tags fetched ({completed}/{len(spec.tag_list)})"
-        return SensorDataSet(time_range=time_range, data=info), None
+
+        return SensorDataSet(time_range=time_range, data=dataframes), None

--- a/app/latigo/utils.py
+++ b/app/latigo/utils.py
@@ -270,3 +270,15 @@ def read_file(fname, strip=True):
 
 def format_error(e):
     return traceback.format_exception(type(e), e, e.__traceback__)
+
+
+def local_datetime_to_utc(target: datetime) -> str:
+    """Make datetime string representation in UTC.
+
+    Return:
+         String representation of without and taking into the account time zone formatted in UTC timezone.
+    """
+    utc_offset_timedelta = datetime.datetime.utcnow() - datetime.datetime.now()
+    target = target.replace(tzinfo=None)
+    result_utc_datetime = target + utc_offset_timedelta
+    return result_utc_datetime.isoformat()


### PR DESCRIPTION
Issue of the "InsufficientDataAfterRowFilteringError" was caused by Latigo itself.
Latigo fetched the data from the Time Series API with "border" data points (but they where filtered, so not a problem). Issue was with the way how Latigo prepares DataFrames for the Gordo predictions: it was mixed between tags somehow, so tag that should be filtered got an average value below filter-value (so it was good bug that helped found not good one cause this mixed data then was sent to Gordo and we wrote wrong predictions).

* comment "print_client_debug(client)" not to spam in the logs
* change "includeOutsidePoints" to False - not to include border points
* fix messing data tags for predictions between them
* TODO "intermediate.py" maybe should be removed

For now part of the machines got the predictions **without the error**, examples:
```
1. [Prediction_task_info] 'ioc-1901.5d43e23d-8dee-4e04-821b-384be56f35a7-9999', prediction: from '2020-04-01 11:00:07.637133+03:00' to '2020-04-01 12:30:07.637133+03:00'
2. [Prediction_task_info] 'ioc-1901.6078716b-c3d7-4b1b-984d-c69d5a1ae1c2-9999', prediction: from '2020-04-01 11:00:07.637133+03:00' to '2020-04-01 12:30:07.637133+03:00'
3. [Prediction_task_info] 'ioc-1901.61048373-08e5-4d2d-804d-4ae8cbbc5dab-9999', prediction: from '2020-04-01 11:00:07.637133+03:00' to '2020-04-01 12:30:07.637133+03:00'
```

Some of the models **has same error, so tags-data should be checked, examples of the 
'InsufficientDataAfterRowFilteringError'**:
```
1. 'ioc-1901.4f544156-afcc-47e4-8b4c-7b66c5db6ea2-9999', prediction: from '2020-04-01 11:00:07.637133+03:00' to '2020-04-01 12:30:07.637133+03:00'.
2. ioc-1901.7e187362-5c69-49b8-ac30-50ec9c363ceb-9999', prediction: from '2020-04-01 11:00:07.637133+03:00' to '2020-04-01 12:30:07.637133+03:00'.
3. 'ioc-1901.c2af8446-98a9-4614-97fa-15b246ceb31b-9999', prediction: from '2020-04-01 11:00:07.637133+03:00' to '2020-04-01 12:30:07.637133+03:00'
4. 'ioc-1901.e3a45ebf-6b78-4870-8089-90993b759870-9999', prediction: from '2020-04-01 11:00:07.637133+03:00' to '2020-04-01 12:30:07.637133+03:00'.
```

Also, there was one strange error:
[Prediction_task_info] 'ioc-1901.ca22a598-eebe-419a-8705-af8894b823bd-9999', prediction: from '2020-04-01 11:00:07.637133+03:00' to '2020-04-01 12:30:07.637133+03:00'
```
File "/latigo/app/latigo/gordo/prediction_execution_provider.py", line 66, in execute_prediction
    revision=revision,
  File "/latigo/venv/lib/python3.7/site-packages/gordo/client/client.py", line 325, in predict
    return [(j.name, j.predictions, j.error_messages) for j in jobs]
  File "/latigo/venv/lib/python3.7/site-packages/gordo/client/client.py", line 325, in <listcomp>
    return [(j.name, j.predictions, j.error_messages) for j in jobs]
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/concurrent/futures/_base.py", line 598, in result_iterator
    yield fs.pop().result()
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/concurrent/futures/_base.py", line 435, in result
    return self.__get_result()
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/latigo/venv/lib/python3.7/site-packages/gordo/client/client.py", line 321, in <lambda>
    machine=ep, start=start, end=end, revision=_revision
  File "/latigo/venv/lib/python3.7/site-packages/gordo/client/client.py", line 349, in predict_single_machine
    X, y = self._raw_data(machine, start, end)
  File "/latigo/venv/lib/python3.7/site-packages/gordo/client/client.py", line 554, in _raw_data
    return dataset.get_data()
  File "/latigo/venv/lib/python3.7/site-packages/gordo/machine/dataset/datasets.py", line 202, in get_data
    aggregation_methods=self.aggregation_methods,
  File "/latigo/venv/lib/python3.7/site-packages/gordo/machine/dataset/base.py", line 149, in join_timeseries
    f"The following features are missing data: {missing_data_series}"
gordo.machine.dataset.base.InsufficientDataError: The following features are missing data: ['1904.T-40TT0250.Value', '1904.T-40VT0257.Enveloped', '1904.T-40VT0258.Enveloped', '1904.T-40VT0256.Enveloped']
```

And eventually, please check **the predictions that was written to the Time Series API** before approving this PR.
Example of the stored data:
```
‘1903.R-29SST2099.MA_Y’
‘dae16ae0-7ad9-4697-b29c-1126d293fd7b’
{‘time’: ‘2020-04-01T07:10:00Z’, ‘value’: 3302.410888671875, ‘status’: ‘0’} ....
```