### PR TITLE
US-14-16005 fix event-hub/kafka timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ Both scheduler and executor has a task_queue configuration. It describes their c
 | client.id | "latigo_scheduler" | See [confluent docs](https://docs.confluent.io/current/installation/configuration/consumer-configs.html). |
 | request.timeout.ms | 10000 | See [confluent docs](https://docs.confluent.io/current/installation/configuration/consumer-configs.html). |
 | session.timeout.ms | 10000 | See [confluent docs](https://docs.confluent.io/current/installation/configuration/consumer-configs.html). |
-| default.topic.config | {"auto.offset.reset": "smallest"} | See [confluent docs](https://docs.confluent.io/current/installation/configuration/consumer-configs.html). |
+| default.topic.config | {"auto.offset.reset": "earliest"} | See [Kafka docs](https://kafka.apache.org/documentation.html#newconsumerconfigs). |
 | debug | "fetch" | See [confluent docs](https://docs.confluent.io/current/installation/configuration/consumer-configs.html). |
 | topic | "latigo_topic" | See [confluent docs](https://docs.confluent.io/current/installation/configuration/consumer-configs.html). |
 | enable.auto.commit | true | See [confluent docs](https://docs.confluent.io/current/installation/configuration/consumer-configs.html). |

--- a/deploy/executor_config.yaml
+++ b/deploy/executor_config.yaml
@@ -13,7 +13,7 @@ task_queue:
     client.id: "executor"
     request.timeout.ms: 10000
     session.timeout.ms: 10000
-    default.topic.config: {"auto.offset.reset": "smallest"}
+    default.topic.config: {"auto.offset.reset": "earliest"}
     debug: "fetch"
     topic: "latigo_topic"
     enable.auto.commit: true

--- a/deploy/scheduler_config.yaml
+++ b/deploy/scheduler_config.yaml
@@ -17,7 +17,7 @@ task_queue:
     client.id: "latigo_scheduler"
     request.timeout.ms: 10000
     session.timeout.ms: 10000
-    default.topic.config: {"auto.offset.reset": "smallest"}
+    default.topic.config: {"auto.offset.reset": "earliest"}
     debug: "fetch"
     topic: "latigo_topic"
     enable.auto.commit: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,7 @@ def config(auth_config):
             "client.id": "executor",
             "request.timeout.ms": 10000,
             "session.timeout.ms": 10000,
-            "default.topic.config": {"auto.offset.reset": "smallest"},
+            "default.topic.config": {"auto.offset.reset": "earliest"},
             "debug": "fetch",
             "topic": "latigo_topic",
             "enable.auto.commit": True,

--- a/tests/integration/test_event_hub.py
+++ b/tests/integration/test_event_hub.py
@@ -24,7 +24,7 @@ def _get_config():
         "client.id": "latigo_scheduler",
         "request.timeout.ms": 10000,
         "session.timeout.ms": 10000,
-        "default.topic.config": {"auto.offset.reset": "smallest"},
+        "default.topic.config": {"auto.offset.reset": "earliest"},
         "debug": "fetch",
         "topic": "latigo_topic",
         "enable.auto.commit": True,


### PR DESCRIPTION
## Description

In Latigo logs were lots of errors and warnings about Kafka.
Main issue was cause of consumers idle. 
Library that is used for Kafka uses callbacks - they were adjusted.
Debug info were added in case of the future similar issues.
Private attributes of Kafka errors are used to prevent error_codes hardcoding.

Also, in configs was replaced "auto.offset.reset" value with new Kafka option "earliest".

## Type of change

Mark the relevant options (`[x]` will mark checkbox as checked).
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

[Azure DevOps Link](https://dev.azure.com/EquinorASA/OMNIA%20Prevent/_sprints/taskboard/OMNIA%20Prevent%20Team/OMNIA%20Prevent/Sprint%207?workitem=16005)