### PR TITLE
19026 Measurement decorator.

### DIFF
--- a/app/latigo/log/__init__.py
+++ b/app/latigo/log/__init__.py
@@ -1,0 +1,2 @@
+from .setup import *
+from .measurement import *

--- a/app/latigo/log/measurement.py
+++ b/app/latigo/log/measurement.py
@@ -1,0 +1,49 @@
+"""Measurement tools for logging."""
+import logging
+from functools import wraps
+from typing import Dict, Any
+
+import attr
+from time import monotonic
+
+__all__ = ["measure"]
+
+default_logger = logging.getLogger(__name__)
+
+
+@attr.s(auto_attribs=True, slots=True)
+class MeasurementContextManager:
+    _context: Dict[str, Any]
+    _logger: logging.Logger = default_logger
+    _level: int = logging.INFO
+    _start_time: float = attr.Factory(monotonic)
+
+    def __enter__(self):
+        self._logger.log(self._level, "Starting measurement.", extra={"context": self._context})
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._context["delta"] = monotonic() - self._start_time
+        status = "failed" if exc_type else "finished"
+        self._logger.log(self._level, "Measured operation %s.", status, extra={"context": self._context})
+
+    def __call__(self, func):
+        @wraps(func)
+        def inner(*args, **kwargs):
+            with attr.evolve(self, context={"operation_id": self._context["operation_id"]}, start_time=monotonic()):
+                return func(*args, **kwargs)
+        return inner
+
+
+def measure(operation_id: str, *, logger=default_logger, level=logging.INFO):
+    """Decorator and context manager for measuring execution time.
+
+    Args:
+        operation_id: human-readable string to identity the operation
+            being measured.
+        logger: logger instance to log measurement results.  If not
+            provided, use default one.
+        level: log level of the measurement result.
+    """
+
+    return MeasurementContextManager({"operation_id": operation_id}, logger=logger, level=level)

--- a/app/latigo/log/setup.py
+++ b/app/latigo/log/setup.py
@@ -9,6 +9,8 @@ import pylogctx
 from colorlog import ColoredFormatter
 from opencensus.ext.azure.log_exporter import AzureLogHandler
 
+__all__ = ["setup_logging"]
+
 LOGS_TO_SUPPRESS = (
     "requests",
     "tensorboard",
@@ -27,7 +29,7 @@ class LatigoFormatter(ColoredFormatter):
 
     def format(self, record):
         """Add extra context to the record."""
-        context = {}
+        context = getattr(record, "context", {})
 
         if record.exc_info:
             context["exception"] = record.exc_info[0].__name__

--- a/app/requirements.in
+++ b/app/requirements.in
@@ -1,3 +1,4 @@
+attrs~=19.3.0
 azure-eventhub~=1.3
 colorlog~=4.0
 gordo~=0.55

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -8,7 +8,7 @@ absl-py==0.9.0            # via tensorboard, tensorflow
 adal==1.2.2               # via azure-datalake-store, msrestazure, requests-ms-auth
 aniso8601==8.0.0          # via flask-restplus
 astor==0.8.1              # via tensorflow
-attrs==19.3.0             # via jsonschema
+attrs==19.3.0             # via -r r.in, jsonschema
 azure-common==1.1.25      # via azure-eventhub, azure-storage-blob, azure-storage-common
 azure-datalake-store==0.0.48  # via gordo
 azure-eventhub==1.3.3     # via -r r.in

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,7 +9,7 @@ devops: unit
 
 unit:
 	# TODO refactor and add here all unit test
-	py.test -vv unit/test_utils.py unit/test_executor.py unit/test_scheduler.py
+	py.test -vv unit/test_utils.py unit/test_executor.py unit/test_scheduler.py unit/test_log.py
 
 utils:
 	py.test -vv unit/test_utils.py

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -1,0 +1,167 @@
+"""Tests for logging functionality."""
+import logging
+from typing import Optional
+from unittest.mock import patch, sentinel, Mock
+
+import pytest
+
+from latigo.log import measure
+from latigo.log.measurement import MeasurementContextManager
+
+
+@pytest.fixture
+def patch_time():
+    with patch("latigo.log.measurement.monotonic", return_value=0) as mock_time:
+        with patch(
+            "latigo.log.measurement.MeasurementContextManager",
+            side_effect=lambda *a, **kw: MeasurementContextManager(*a, start_time=mock_time(), **kw),
+        ):
+            yield mock_time
+
+
+@pytest.fixture
+def advance(patch_time, caplog):
+    """Move patched clock forward, execute a callback if one provided.
+
+    Also provide some useful updates for log records.
+    """
+
+    def do_adwance(time: float, callback: Optional[callable] = None):
+        # Copy context since it is updated between calls.
+        for record in caplog.records:
+            if hasattr(record, "context"):
+                record.context = record.context.copy()
+
+        patch_time.return_value += time
+        if callback:
+            return callback()
+
+    return do_adwance
+
+
+def test_measure_decorator(advance, caplog):
+    # Create decorator, wrap the function and call it.
+    result = measure("test_measure")(advance)(123.45, lambda: sentinel.return_value)
+    assert result == sentinel.return_value
+
+    assert caplog.record_tuples == [
+        ("latigo.log.measurement", logging.INFO, "Starting measurement."),
+        ("latigo.log.measurement", logging.INFO, "Measured operation finished."),
+    ]
+
+    setup_record, teardown_record = caplog.records
+    assert setup_record.context == {"operation_id": "test_measure"}
+    assert teardown_record.context == {"delta": 123.45, "operation_id": "test_measure"}
+
+
+def test_measure_decorator_call_twice(advance, caplog):
+    decorated_func = measure("test_measure")(advance)
+
+    decorated_func(100)
+    decorated_func(50)
+
+    assert caplog.record_tuples == [
+        ("latigo.log.measurement", logging.INFO, "Starting measurement."),
+        ("latigo.log.measurement", logging.INFO, "Measured operation finished."),
+        ("latigo.log.measurement", logging.INFO, "Starting measurement."),
+        ("latigo.log.measurement", logging.INFO, "Measured operation finished."),
+    ]
+
+    contexts = [r.context for r in caplog.records]
+    assert contexts == [
+        {"operation_id": "test_measure"},
+        {"delta": 100, "operation_id": "test_measure"},
+        {"operation_id": "test_measure"},
+        {"delta": 50, "operation_id": "test_measure"},
+    ]
+
+
+def test_measure_decorator_fails(advance, caplog):
+    # Create decorator, wrap the function and call it.
+    with pytest.raises(KeyError, match=r":-\)"):
+        measure("test_measure")(advance)(123.45, Mock(side_effect=KeyError(":-)")))
+
+    assert caplog.record_tuples == [
+        ("latigo.log.measurement", logging.INFO, "Starting measurement."),
+        ("latigo.log.measurement", logging.INFO, "Measured operation failed."),
+    ]
+
+    setup_record, teardown_record = caplog.records
+    assert setup_record.context == {"operation_id": "test_measure"}
+    assert teardown_record.context == {"delta": 123.45, "operation_id": "test_measure"}
+
+
+def test_measure_context_manager(advance, caplog):
+    with measure("test_measure"):
+        advance(123.45)
+
+    assert caplog.record_tuples == [
+        ("latigo.log.measurement", logging.INFO, "Starting measurement."),
+        ("latigo.log.measurement", logging.INFO, "Measured operation finished."),
+    ]
+
+    setup_record, teardown_record = caplog.records
+    assert setup_record.context == {"operation_id": "test_measure"}
+    assert teardown_record.context == {"delta": 123.45, "operation_id": "test_measure"}
+
+
+def test_measure_context_manager_failure(advance, caplog):
+    with pytest.raises(RuntimeError), measure("test_measure"):
+        advance(123.45)
+        raise RuntimeError
+
+    assert caplog.record_tuples == [
+        ("latigo.log.measurement", logging.INFO, "Starting measurement."),
+        ("latigo.log.measurement", logging.INFO, "Measured operation failed."),
+    ]
+
+    setup_record, teardown_record = caplog.records
+    assert setup_record.context == {"operation_id": "test_measure"}
+    assert teardown_record.context == {"delta": 123.45, "operation_id": "test_measure"}
+
+
+def test_measure_custom_logger(advance, caplog):
+    with measure("test_measure", logger=logging.getLogger("latigo.test-logger")):
+        advance(123.45)
+
+    assert caplog.record_tuples == [
+        ("latigo.test-logger", logging.INFO, "Starting measurement."),
+        ("latigo.test-logger", logging.INFO, "Measured operation finished."),
+    ]
+
+    setup_record, teardown_record = caplog.records
+    assert setup_record.context == {"operation_id": "test_measure"}
+    assert teardown_record.context == {"delta": 123.45, "operation_id": "test_measure"}
+
+
+def test_measure_custom_level(advance, caplog):
+    caplog.set_level(logging.DEBUG)
+    with measure("test_measure", level=logging.DEBUG):
+        advance(123.45)
+
+    assert caplog.record_tuples == [
+        ("latigo.log.measurement", logging.DEBUG, "Starting measurement."),
+        ("latigo.log.measurement", logging.DEBUG, "Measured operation finished."),
+    ]
+
+    setup_record, teardown_record = caplog.records
+    assert setup_record.context == {"operation_id": "test_measure"}
+    assert teardown_record.context == {"delta": 123.45, "operation_id": "test_measure"}
+
+
+def test_measure_two_functions(advance, caplog):
+    with measure("test_measure"):
+        advance(123.45)
+        logging.info("Intermediate log.")
+        advance(67.89)
+
+    assert caplog.record_tuples == [
+        ("latigo.log.measurement", logging.INFO, "Starting measurement."),
+        ("root", logging.INFO, "Intermediate log."),
+        ("latigo.log.measurement", logging.INFO, "Measured operation finished."),
+    ]
+
+    setup_record, intermediate_record, teardown_record = caplog.records
+    assert setup_record.context == {"operation_id": "test_measure"}
+    assert teardown_record.context == {"delta": 191.34, "operation_id": "test_measure"}
+    assert not hasattr(intermediate_record, "context")


### PR DESCRIPTION
Introduce `measure` decorator-context manager for measuring code execution duration.  For now only log-based measurement is used.

To be used in two ways: as a decorator and as a context manager.  Examples:

```python
logger = logging.getLogger(__name__)


@measure("do something", logger=logger)
def do_something():
   ...


with measure("debug a bit of code", level=logging.DEBUG):
    do_something()
    do_something_else()
```
 