### PR TITLE
pass image version explicitly to push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,10 +164,8 @@ scan:  ## Scan images for vulnerabilities
 
 ############### Push docker images ####################
 push:  ## Push image
-	export DOCKER_NAME=${LATIGO_BASE_IMAGE_NAME};\
-	export DOCKER_IMAGE=${LATIGO_BASE_IMAGE_NAME};\
-	echo "Pushing imge ${DOCKER_NAME}";\
-	bash -x deploy/docker_push.sh
+	echo "Pushing image '${LATIGO_BASE_IMAGE_NAME}' with version '${LATIGO_VERSION}'";\
+	bash -x deploy/docker_push.sh ${LATIGO_BASE_IMAGE_NAME} ${LATIGO_BASE_IMAGE_NAME} ${LATIGO_VERSION}
 
 ############### Docker cleanup ####################
 prune:  ## Prune docker


### PR DESCRIPTION
## Description

pass image version explicitly to push.
Remove "magic" of getting it from file repeatedly.
With out this fix push will be with some default tag.

## Type of change

Mark the relevant options (`[x]` will mark checkbox as checked).
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

# Checklist:

- [ ] I have made corresponding changes to the documentation / README (if needed)
- [ ] I have added tests that prove my fix is effective or that my feature works (if needed)
